### PR TITLE
Create UploadableFile Trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,28 @@ $this->crud->addField([
 ]);
 ```
 
+### Upload Field : `file_upload_crud` validation rule
+
+A validation rule exists to easily validate CRUD request with "upload" field.
+
+Example of usage in your requests files:
+```php
+public function rules()
+{
+    return [
+        'name' => 'required|min:2|max:191',           
+        'document' => 'file_upload_crud:pdf,docx', // the parameters must be valid mime types
+    ];
+}
+
+public function messages()
+{
+    return [
+        'file_upload_crud' => 'The :attribute must be a valid file.',
+    ];
+}
+```
+
 ### Image Field : `UploadableImage` Trait
 
 If you use Image CRUD Field, you can implement this Trait on your Model to automatically upload / delete image(s) on server.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,63 @@ You can use it in your own views like this:
 {{ trans($crud->getLangFile().'.add') }}
 ```
 
+### Upload Field : `UploadableFile` Trait
+
+If you use Upload CRUD Field, you can implement this Trait on your Model to automatically upload / delete file(s) on server.
+
+Example:
+```php
+// Article Model
+
+class Article extends \Backpack\NewsCRUD\app\Models\Article
+{
+    use Sluggable, SluggableScopeHelpers;
+    use HasTranslations;
+    use UploadableFile;
+
+    protected $fillable = ['slug', 'title', 'content', 'image', 'status', 'category_id', 'featured', 'date', 'document', 'document_2'];
+    protected $translatable = ['slug', 'title', 'content'];
+
+    public function uploadableFiles(): array
+    {
+        return [
+            ['name' => 'document'],
+            ['name' => 'document_2', 'slug' => 'title']
+        ];
+    }
+}
+```
+
+```php
+// ArticleCrudController
+
+$this->crud->addField([ 
+    'label' => 'Image',
+    'name' => 'image',
+    'type' => 'image',
+    'upload' => true,
+    'crop' => true, // set to true to allow cropping, false to disable
+    'aspect_ratio' => 0, // ommit or set to 0 to allow any aspect ratio
+    'prefix' => '/storage/',
+]);
+
+$this->crud->addField([
+    'label' => 'Document',
+    'name' => 'document',
+    'type' => 'upload',
+    'upload' => true,
+    'prefix' => '/storage/',
+]);
+
+$this->crud->addField([
+    'label' => 'Document 2',
+    'name' => 'document_2',
+    'type' => 'upload',
+    'upload' => true,
+    'prefix' => '/storage/',
+]);
+```
+
 ### Image Field : `UploadableImage` Trait
 
 If you use Image CRUD Field, you can implement this Trait on your Model to automatically upload / delete image(s) on server.

--- a/src/CrudServiceProvider.php
+++ b/src/CrudServiceProvider.php
@@ -3,6 +3,8 @@
 namespace Novius\Backpack\CRUD;
 
 use Backpack\CRUD\CrudServiceProvider as BackpackCrudServiceProvider;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Validator;
 
 class CrudServiceProvider extends BackpackCrudServiceProvider
 {
@@ -43,6 +45,18 @@ class CrudServiceProvider extends BackpackCrudServiceProvider
          */
         app()->bind(\Backpack\CRUD\CrudPanel::class, function () {
             return new CrudPanel();
+        });
+
+        // Add a validation rule for Upload Field
+        Validator::extend('file_upload_crud', function ($attribute, $value, $parameters, $validator) {
+            $isValidFile = false;
+            if (is_a($value, UploadedFile::class)) {
+                $rules = [$attribute => 'mimes:'.implode(',', $parameters)];
+                $input = [$attribute => $value];
+                $isValidFile = Validator::make($input, $rules)->passes();
+            }
+
+            return is_string($value) || $isValidFile;
         });
     }
 

--- a/src/ModelTraits/UploadableFile.php
+++ b/src/ModelTraits/UploadableFile.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Novius\Backpack\CRUD\ModelTraits;
+
+use Novius\Backpack\CRUD\Observers\UploadFileObserver;
+use Novius\Backpack\CRUD\Services\UploadFileService;
+
+trait UploadableFile
+{
+    /**
+     * Hook into the Eloquent model events to upload or delete elements
+     */
+    public static function bootUploadableFile()
+    {
+        // We need to create a shared instance of Observer (only on this model) to keep some information at each fired events
+        $observer = new UploadFileObserver(new UploadFileService());
+        app()->instance(UploadFileObserver::class, $observer);
+
+        // Observe Model Events with same instance of observer
+        static::observe(app(UploadFileObserver::class));
+    }
+
+    /**
+     * Put value on desired model image attribute
+     *
+     * @param string $fileAttributeName
+     * @param string $path
+     */
+    public function fillUploadedFileAttributeValue(string $fileAttributeName, string $path)
+    {
+        $this->{$fileAttributeName} = $path;
+    }
+
+    /**
+     * Get model attributes name for files upload
+     * Simple example: return ['name' => 'document', slug' => 'title'];
+     * With multiple files: return [['name' => 'document', slug' => 'title'], ['name' => 'image']];
+     *
+     * @return array
+     */
+    abstract public function uploadableFiles(): array;
+}

--- a/src/Observers/UploadFileObserver.php
+++ b/src/Observers/UploadFileObserver.php
@@ -4,23 +4,23 @@ namespace Novius\Backpack\CRUD\Observers;
 
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Eloquent\Model;
+use Novius\Backpack\CRUD\Services\UploadFileService;
 use Novius\Backpack\CRUD\Services\UploadImageService;
 
-class UploadImageObserver
+class UploadFileObserver
 {
+    /**
+     * @var UploadFileService
+     */
+    private $uploadFileService;
 
     /**
-     * @var \Cviebrock\EloquentSluggable\Services\SlugService
+     * UploadFileObserver constructor.
+     * @param UploadFileService $uploadFileService
      */
-    private $imageUploadService;
-
-    /**
-     * UploadImageObserver constructor.
-     * @param UploadImageService $imageUploadService
-     */
-    public function __construct(UploadImageService $imageUploadService)
+    public function __construct(UploadFileService $uploadFileService)
     {
-        $this->imageUploadService = $imageUploadService;
+        $this->uploadFileService = $uploadFileService;
     }
 
     /**
@@ -28,7 +28,7 @@ class UploadImageObserver
      */
     public function saving(Model $model)
     {
-        $this->imageUploadService->fillImages($model);
+        $this->uploadFileService->fillFiles($model);
     }
 
     /**
@@ -36,7 +36,7 @@ class UploadImageObserver
      */
     public function saved(Model $model)
     {
-        $this->imageUploadService->saveImages($model);
+        $this->uploadFileService->saveFiles($model);
     }
 
     /**
@@ -44,7 +44,6 @@ class UploadImageObserver
      */
     public function deleting(Model $model)
     {
-        $this->imageUploadService->deleteImages($model);
+        $this->uploadFileService->deleteFiles($model);
     }
-
 }

--- a/src/Services/AbstractUploadService.php
+++ b/src/Services/AbstractUploadService.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Novius\Backpack\CRUD\Services;
+
+use Illuminate\Database\Eloquent\Model;
+
+abstract class AbstractUploadService
+{
+    const STORAGE_DISK_NAME = 'public'; // @TODO : make this option configurable
+
+    /**
+     * @var \Illuminate\Database\Eloquent\Model;
+     */
+    protected $model;
+
+    /**
+     * Get files attributes names
+     *
+     * @param array $uploableFiles
+     * @return array
+     */
+    protected function filesAttributes(array $uploableFiles): array
+    {
+        if (array_get($uploableFiles, 0) === null) {
+            $uploableFiles = [$uploableFiles];
+        }
+
+        return array_pluck($uploableFiles, 'name');
+    }
+
+    /**
+     * Get slug attributes name (image attributes key based)
+     *
+     * @param array $uploableFiles
+     * @return array
+     */
+    protected function slugAttributes(array $uploableFiles): array
+    {
+        if (array_get($uploableFiles, 0) === null) {
+            $uploableFiles = [$uploableFiles];
+        }
+
+        return array_pluck($uploableFiles, 'slug', 'name');
+    }
+
+    /**
+     * Init the service Model
+     *
+     * @param Model $model
+     */
+    protected function initModel(Model $model)
+    {
+        $this->model = $model;
+    }
+}

--- a/src/Services/UploadFileService.php
+++ b/src/Services/UploadFileService.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Novius\Backpack\CRUD\Services;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
+
+/**
+ * Class UploadFileService
+ * @package Novius\Backpack\CRUD\Services
+ */
+class UploadFileService extends AbstractUploadService
+{
+    /**
+     * Filled with files during model saving
+     * Images will be used on Model "saved" event
+     *
+     * @var array
+     */
+    protected $tmpFiles = [];
+
+    /**
+     * Set Model files attributes with good values
+     *
+     * @param Model $model
+     * @return bool
+     */
+    public function fillFiles(Model $model)
+    {
+        $this->initModel($model);
+        foreach ($this->filesAttributes($this->model->uploadableFiles()) as $fileAttributeName) {
+            $this->setUploadedFile($fileAttributeName);
+        }
+
+        return true;
+    }
+
+    /**
+     * Save files on disk and update Model columns with files path
+     *
+     * @param Model $model
+     * @return bool
+     */
+    public function saveFiles(Model $model)
+    {
+        $this->initModel($model);
+
+        if (empty($this->tmpFiles)) {
+            return true;
+        }
+
+        foreach ($this->tmpFiles as $fileAttributeName => $file) {
+            // 1. Get image path
+            $destinationPath = $this->getDestinationPath($fileAttributeName);
+            $fileName = $this->getFilename($file, $fileAttributeName);
+
+            // 2. Move the new file to the correct path
+            $filePath = $file->storeAs($destinationPath, $fileName, self::STORAGE_DISK_NAME);
+
+            // 3. Save the path to the database
+            $this->model->fillUploadedFileAttributeValue($fileAttributeName, $filePath);
+
+            if (isset($this->tmpFiles[$fileAttributeName])) {
+                unset($this->tmpFiles[$fileAttributeName]);
+            }
+        }
+
+        return $this->model->save();
+    }
+
+    protected function getFilename(UploadedFile $file, string $fileAttributeName): string
+    {
+        $slugAttributeName = array_get($this->slugAttributes($this->model->uploadableFiles()), $fileAttributeName);
+        $filename = md5(time());
+        if (!empty($slugAttributeName)) {
+            $filename = str_slug($this->model->{$slugAttributeName});
+        }
+        $filename .= '.'.$file->getClientOriginalExtension();
+
+        return $filename;
+    }
+
+    /**
+     * @param string $fileAttributeName
+     * @return string
+     */
+    protected function getDestinationPath(string $fileAttributeName): string
+    {
+        $folderName = snake_case(class_basename(get_class($this->model)));
+        $destination_path = $folderName.'/'.$this->model->getKey().'/'.$fileAttributeName;
+
+        return $destination_path;
+    }
+
+    /**
+     * Delete images on disk
+     *
+     * @param Model $model
+     * @return bool
+     */
+    public function deleteFiles(Model $model)
+    {
+        $this->initModel($model);
+        foreach ($this->filesAttributes($this->model->uploadableFiles()) as $fileAttribute) {
+            \Storage::disk(self::STORAGE_DISK_NAME)->delete($this->model->{$fileAttribute});
+        }
+
+        return true;
+    }
+
+    /**
+     * Fill Model image attribute with good value
+     *
+     * @param string $fileAttributeName
+     */
+    protected function setUploadedFile(string $fileAttributeName)
+    {
+        /**
+         * @var Request
+         */
+        $request = \Request::instance();
+        $fileAttributeValue = $this->model->getAttribute($fileAttributeName);
+
+        // If a new file is uploaded, delete old file from the disk
+        if ($request->hasFile($fileAttributeName) && !empty($this->model->getOriginal($fileAttributeName)) && is_string($fileAttributeValue)) {
+            \Storage::disk(self::STORAGE_DISK_NAME)->delete($this->model->getOriginal($fileAttributeName));
+            $this->model->fillUploadedFileAttributeValue($fileAttributeName, '');
+        }
+
+        // if the file input is empty, delete the file from the disk
+        if (!$request->hasFile($fileAttributeName) && $request->get($fileAttributeName) === null && !empty($this->model->getOriginal($fileAttributeName))) {
+            \Storage::disk(self::STORAGE_DISK_NAME)->delete($this->model->getOriginal($fileAttributeName));
+            $this->model->fillUploadedFileAttributeValue($fileAttributeName, '');
+        }
+
+        // if a new file is uploaded, store it on disk and its filename in the database
+        if ($request->hasFile($fileAttributeName) && $request->file($fileAttributeName)->isValid() && is_a($fileAttributeValue, UploadedFile::class)) {
+            // 1. Generate a new file name
+            $file = $request->file($fileAttributeName);
+            $this->tmpFiles[$fileAttributeName] = $file;
+        }
+    }
+}


### PR DESCRIPTION
### Upload Field : `UploadableFile` Trait

If you use Upload CRUD Field, you can implement this Trait on your Model to automatically upload / delete file(s) on server.

Example:
```php
// Article Model

class Article extends \Backpack\NewsCRUD\app\Models\Article
{
    use Sluggable, SluggableScopeHelpers;
    use HasTranslations;
    use UploadableFile;

    protected $fillable = ['slug', 'title', 'content', 'image', 'status', 'category_id', 'featured', 'date', 'document', 'document_2'];
    protected $translatable = ['slug', 'title', 'content'];

    public function uploadableFiles(): array
    {
        return [
            ['name' => 'document'],
            ['name' => 'document_2', 'slug' => 'title']
        ];
    }
}
```

```php
// ArticleCrudController

$this->crud->addField([ 
    'label' => 'Image',
    'name' => 'image',
    'type' => 'image',
    'upload' => true,
    'crop' => true, // set to true to allow cropping, false to disable
    'aspect_ratio' => 0, // ommit or set to 0 to allow any aspect ratio
    'prefix' => '/storage/',
]);

$this->crud->addField([
    'label' => 'Document',
    'name' => 'document',
    'type' => 'upload',
    'upload' => true,
    'prefix' => '/storage/',
]);

$this->crud->addField([
    'label' => 'Document 2',
    'name' => 'document_2',
    'type' => 'upload',
    'upload' => true,
    'prefix' => '/storage/',
]);
```

### Upload Field : `file_upload_crud` validation rule

A validation rule exists to easily validate CRUD request with "upload" field.

Example of usage in your requests files:
```php
public function rules()
{
    return [
        'name' => 'required|min:2|max:191',           
        'document' => 'file_upload_crud:pdf,docx', // the parameters must be valid mime types
    ];
}

public function messages()
{
    return [
        'file_upload_crud' => 'The :attribute must be a valid file.',
    ];
}
```