### PR TITLE
Able to validate request + prevent duplicate input name

### DIFF
--- a/resources/views/fields/upload.blade.php
+++ b/resources/views/fields/upload.blade.php
@@ -18,14 +18,24 @@
         </div>
     @endif
 
-    {{-- Show the file picker on CREATE form. --}}
-    <input
-            type="file"
-            id="{{ $field['name'] }}_file_input"
-            name="{{ $field['name'] }}"
-            value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
-            @include('crud::inc.field_attributes', ['default_class' =>  isset($field['value']) && $field['value']!=null?'form-control hidden':'form-control'])
-    >
+    @if (isset($field['value']) && $field['value'] !== null)
+        {{-- File already exists : put the path value to hidden file  --}}
+        <input
+                type="hidden"
+                id="{{ $field['name'] }}_file_input"
+                name="{{ $field['name'] }}"
+                value="{{ $field['value'] }}"
+                @include('crud::inc.field_attributes', ['default_class' =>  'form-control']) />
+    @else
+        {{-- File not exists : display an input file --}}
+        <input
+                type="file"
+                id="{{ $field['name'] }}_file_input"
+                name="{{ $field['name'] }}"
+                value="{{ isset($field['default']) ? $field['default'] : '' }}"
+                @include('crud::inc.field_attributes', ['default_class' => 'form-control'])
+        />
+    @endif
 
     {{-- HINT --}}
     @if (isset($field['hint']))
@@ -37,23 +47,14 @@
 {{-- push things in the after_scripts section --}}
 
 @push('crud_fields_scripts')
-<!-- no scripts -->
-<script>
-    $("#{{ $field['name'] }}_file_clear_button").click(function(e) {
-        e.preventDefault();
-        $(this).parent().addClass('hidden');
-
-        var input = $("#{{ $field['name'] }}_file_input");
-        input.removeClass('hidden');
-        input.attr("value", "").replaceWith(input.clone(true));
-        // add a hidden input with the same name, so that the setXAttribute method is triggered
-        $("<input type='hidden' name='{{ $field['name'] }}' value=''>").insertAfter("#{{ $field['name'] }}_file_input");
-    });
-
-    $("#{{ $field['name'] }}_file_input").change(function() {
-        console.log($(this).val());
-        // remove the hidden input, so that the setXAttribute method is no longer triggered
-        $(this).next("input[type=hidden]").remove();
-    });
-</script>
+    <!-- no scripts -->
+    <script>
+        $("#{{ $field['name'] }}_file_clear_button").click(function(e) {
+            e.preventDefault();
+            $(this).parent().addClass('hidden');
+            // Replace input hidden by an input file and show it
+            var $input = $("#{{ $field['name'] }}_file_input");
+            $input.replaceWith($input.clone().attr('type', 'file').val('').removeClass('hidden'));
+        });
+    </script>
 @endpush

--- a/resources/views/fields/upload.blade.php
+++ b/resources/views/fields/upload.blade.php
@@ -18,24 +18,26 @@
         </div>
     @endif
 
-    @if (isset($field['value']) && $field['value'] !== null)
-        {{-- File already exists : put the path value to hidden file  --}}
-        <input
-                type="hidden"
-                id="{{ $field['name'] }}_file_input"
-                name="{{ $field['name'] }}"
-                value="{{ $field['value'] }}"
-                @include('crud::inc.field_attributes', ['default_class' =>  'form-control']) />
-    @else
-        {{-- File not exists : display an input file --}}
-        <input
-                type="file"
-                id="{{ $field['name'] }}_file_input"
-                name="{{ $field['name'] }}"
-                value="{{ isset($field['default']) ? $field['default'] : '' }}"
-                @include('crud::inc.field_attributes', ['default_class' => 'form-control'])
-        />
-    @endif
+    <div class="js-parent-input">
+        @if (isset($field['value']) && $field['value'] !== null)
+            {{-- File already exists : put the path value to hidden file  --}}
+            <input
+                    type="hidden"
+                    id="{{ $field['name'] }}_file_input"
+                    name="{{ $field['name'] }}"
+                    value="{{ $field['value'] }}"
+                    @include('crud::inc.field_attributes', ['default_class' =>  'form-control']) />
+        @else
+            {{-- File not exists : display an input file --}}
+            <input
+                    type="file"
+                    id="{{ $field['name'] }}_file_input"
+                    name="{{ $field['name'] }}"
+                    value="{{ isset($field['default']) ? $field['default'] : '' }}"
+                    @include('crud::inc.field_attributes', ['default_class' => 'form-control'])
+            />
+        @endif
+    </div>
 
     {{-- HINT --}}
     @if (isset($field['hint']))
@@ -49,12 +51,23 @@
 @push('crud_fields_scripts')
     <!-- no scripts -->
     <script>
-        $("#{{ $field['name'] }}_file_clear_button").click(function(e) {
+        $("#{{ $field['name'] }}_file_clear_button").click(function (e) {
             e.preventDefault();
             $(this).parent().addClass('hidden');
             // Replace input hidden by an input file and show it
             var $input = $("#{{ $field['name'] }}_file_input");
-            $input.replaceWith($input.clone().attr('type', 'file').val('').removeClass('hidden'));
+            var $parent = $input.parent();
+            var $newInput = $('<input type="file" name="{{ $field['name'] }}" />');
+            $newInput.addClass($input.attr('class')).attr('id', $input.attr('id'));
+            $parent.append($newInput);
+            $input.remove(); // Remove to force browser to clear val()
+            // Add an hidden input with the same name, so that the setXAttribute method is triggered by the Eloquent Model
+            $parent.append($("<input type='hidden' name='{{ $field['name'] }}' value=''>"));
+        });
+
+        $('.js-parent-input').on('change', 'input[type="file"]', function () {
+            // Remove hidden file if user browse a file
+            $(this).next("input[type=hidden]").remove();
         });
     </script>
 @endpush

--- a/resources/views/fields/upload.blade.php
+++ b/resources/views/fields/upload.blade.php
@@ -19,7 +19,7 @@
     @endif
 
     <div class="js-parent-input">
-        @if (isset($field['value']) && $field['value'] !== null)
+        @if (!empty($field['value']))
             {{-- File already exists : put the path value to hidden file  --}}
             <input
                     type="hidden"
@@ -33,9 +33,16 @@
                     type="file"
                     id="{{ $field['name'] }}_file_input"
                     name="{{ $field['name'] }}"
-                    value="{{ isset($field['default']) ? $field['default'] : '' }}"
+                    value=""
                     @include('crud::inc.field_attributes', ['default_class' => 'form-control'])
             />
+            @if (!empty($field['default']))
+                <input
+                        type="hidden"
+                        name="{{ $field['name'] }}"
+                        value="{{ $field['default'] }}"
+                />
+            @endif
         @endif
     </div>
 


### PR DESCRIPTION
- Remove console.log()
- Able to validate request with "file_upload_crud" rule (see https://github.com/novius/laravel-backpack-crud-extended/pull/7) (old file path is now sent in hidden input when no change)