### PR TITLE
Feature/permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ php artisan vendor:publish --provider="Novius\Backpack\CRUD\CrudServiceProvider"
 
 ### Configuration
 
+Some options that you can override are available.
+
 ```sh
 php artisan vendor:publish --provider="Novius\Backpack\CRUD\CrudServiceProvider" --tag="config"
 ```

--- a/README.md
+++ b/README.md
@@ -41,8 +41,37 @@ You have to remove views into `resources/views/vendor/backpack/crud/`, or to ove
 php artisan vendor:publish --provider="Novius\Backpack\CRUD\CrudServiceProvider" --force
 ```
 
+### Configuration
+
+```sh
+php artisan vendor:publish --provider="Novius\Backpack\CRUD\CrudServiceProvider" --tag="config"
+```
+
 
 ## Usage & Features
+
+### Permissions
+
+#### Description
+- Permissions can be applied automatically to CRUD Controllers : deny access if user hasn't the permission linked to the route => `apply_permissions` option
+- Permissions can be automatically created for all Crud Controllers used in you application (4 permissions will be created : list, update, create, delete) => `create_permissions_while_browsing` option
+- Permissions can be automatically given to the logged user (useful in local environment)  => `give_permissions_to_current_user_while_browsing` option
+
+#### Requirements
+
+- This feature require : [Laravel-Backpack/PermissionManager](https://github.com/Laravel-Backpack/PermissionManager)
+- You have to publish config file :
+
+```sh
+php artisan permissions:generate // Insert permissions in database for each CRUD controllers.
+```
+
+- Set to true each options that you want activate
+
+#### Usage
+
+Your CrudController must extend `\Novius\Backpack\CRUD\Http\Controllers\CrudController`
+
 
 ### CRUD Boxes
 

--- a/config/crud-extended.php
+++ b/config/crud-extended.php
@@ -1,0 +1,27 @@
+<?php
+
+return [
+    /*
+    |------------
+    | PERMISSIONS
+    |------------
+    */
+
+    // Automatically applies permissions to CRUD controllers. Requires the Backpack/PermissionManager package.
+    //
+    // Each CRUD controller should have a unique prefix for its permission keys. By default the prefix is automatically
+    // derived from the controller's namespace but you can set your own (see the setPermissionsPrefix() method).
+    //
+    // This prefix will then be used to match the permissions handled by the permission manager.
+    //
+    'apply_permissions' => false,
+
+    // Creates the CRUD's permissions in database while browsing in admin.
+    'create_permissions_while_browsing' => false,
+
+    // Gives the CRUD's permissions to the currently connected user while browsing in admin. Should be disabled in production.
+    'give_permissions_to_current_user_while_browsing' => false,
+
+    // Words that are excluded from the auto generated permission prefix (based on route's controller namespace).
+    'excluded_words_from_default_permission_prefix' => ['app', 'http', 'controllers', 'controller', 'crud'],
+];

--- a/src/Console/PermissionsCommand.php
+++ b/src/Console/PermissionsCommand.php
@@ -4,7 +4,7 @@ namespace Novius\Backpack\CRUD\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Route;
-use Backpack\CRUD\app\Http\Controllers\CrudController;
+use Novius\Backpack\CRUD\Http\Controllers\CrudController;
 
 class PermissionsCommand extends Command
 {

--- a/src/Console/PermissionsCommand.php
+++ b/src/Console/PermissionsCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Novius\Backpack\CRUD\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Route;
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+
+class PermissionsCommand extends Command
+{
+    protected $signature = 'permissions:generate';
+
+    protected $description = 'Insert permissions in database for each CRUD controllers.';
+
+    /**
+     * Create permissions in database for each CRUD controllers.
+     *
+     * Available only if Backpack\PermissionManager is installed
+     */
+    public function handle()
+    {
+        // Checks if the PermissionManagerServiceProvider exists
+        if (! class_exists('Backpack\PermissionManager\PermissionManagerServiceProvider')) {
+            return $this->error('Requires the package Backpack\PermissionManager.');
+        }
+
+        // Gets all routes
+        collect(Route::getRoutes())
+
+            // Groups routes by controller
+            ->groupBy(function ($route) {
+                list($controller) = explode('@', array_get($route->getAction(), 'controller'));
+
+                return $controller;
+            })
+
+            // Keeps only the routes handled by a CRUD controller
+            ->filter(function ($routes, $controller) {
+                return ! empty($controller) && is_subclass_of($controller, CrudController::class);
+            })
+
+            // Creates the permissions
+            ->each(function ($routes) {
+                $route = $routes->first();
+                if (method_exists($route->getController()->crud, 'createMissingPermissions')) {
+                    $route->getController()->crud->createMissingPermissions();
+                }
+            });
+
+        return $this->info('Permissions successfully generated.');
+    }
+}

--- a/src/CrudPanel.php
+++ b/src/CrudPanel.php
@@ -5,11 +5,15 @@ namespace Novius\Backpack\CRUD;
 use Backpack\CRUD\CrudPanel as BackpackCrudPanel;
 use Novius\Backpack\CRUD\PanelTraits\Boxes;
 use Novius\Backpack\CRUD\PanelTraits\BoxTabs;
+use Novius\Backpack\CRUD\PanelTraits\Permissions;
 
 class CrudPanel extends BackpackCrudPanel
 {
     use Boxes;
     use BoxTabs;
+    use Permissions;
+
+    public $controller; // a reference to the controller from which this CrudPanel was instantiated
 
     protected $langFile;
 

--- a/src/CrudServiceProvider.php
+++ b/src/CrudServiceProvider.php
@@ -5,9 +5,11 @@ namespace Novius\Backpack\CRUD;
 use Backpack\CRUD\CrudServiceProvider as BackpackCrudServiceProvider;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Validator;
+use Novius\Backpack\CRUD\Console\PermissionsCommand;
 
 class CrudServiceProvider extends BackpackCrudServiceProvider
 {
+    protected static $configName = 'crud-extended';
     /**
      * Perform post-registration booting of services.
      *
@@ -40,6 +42,11 @@ class CrudServiceProvider extends BackpackCrudServiceProvider
         $this->publishes([dirname(__DIR__).'/resources/views' => resource_path('views/vendor/backpack/crud')], 'views');
 
         /*
+         * Publish config
+         */
+        $this->publishes([__DIR__.'/../config/'.static::$configName.'.php' => config_path(static::$configName.'.php')], 'config');
+
+        /*
          * Overrides original CrudPanel
          * Now, Novius\Backpack\CRUD\CrudPanel is automatically used by all backpack controllers
          */
@@ -68,5 +75,15 @@ class CrudServiceProvider extends BackpackCrudServiceProvider
     public function register()
     {
         parent::register();
+
+        // Load config
+        $configPath = __DIR__.'/../config/'.static::$configName.'.php';
+        $this->mergeConfigFrom($configPath, static::$configName);
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                PermissionsCommand::class,
+            ]);
+        }
     }
 }

--- a/src/Http/Controllers/CrudController.php
+++ b/src/Http/Controllers/CrudController.php
@@ -22,6 +22,7 @@ class CrudController extends \Backpack\CRUD\app\Http\Controllers\CrudController
                 if (method_exists($this->crud, 'initPermissions')) {
                     $this->crud->initPermissions();
                 }
+
                 return $next($request);
             });
         }

--- a/src/Http/Controllers/CrudController.php
+++ b/src/Http/Controllers/CrudController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Novius\Backpack\CRUD\Http\Controllers;
+
+use Novius\Backpack\CRUD\CrudPanel;
+
+class CrudController extends \Backpack\CRUD\app\Http\Controllers\CrudController
+{
+    public function __construct()
+    {
+        if (! $this->crud) {
+            $this->crud = app()->make(CrudPanel::class);
+            // Stores a reference to the current controller
+            $this->crud->controller = $this;
+            // call the setup function inside this closure to also have the request there
+            // this way, developers can use things stored in session (auth variables, etc)
+            $this->middleware(function ($request, $next) {
+                // Stores a reference to the current request
+                $this->crud->request = $this->request = $request;
+                $this->setup();
+                // Initializes the CRUD permissions
+                if (method_exists($this->crud, 'initPermissions')) {
+                    $this->crud->initPermissions();
+                }
+                return $next($request);
+            });
+        }
+    }
+}

--- a/src/PanelTraits/Permissions.php
+++ b/src/PanelTraits/Permissions.php
@@ -1,0 +1,272 @@
+<?php
+
+namespace Novius\Backpack\CRUD\PanelTraits;
+
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+use Spatie\Permission\Exceptions\PermissionDoesNotExist;
+
+trait Permissions
+{
+    protected $availablePermissions = ['list', 'create', 'update', 'delete'];
+    protected $permissionsPrefix;
+    protected $defaultPermissionPrefix;
+
+    /**
+     * Initializes the permissions for the current CRUD controller.
+     *
+     * Available only if Backpack\PermissionManager is installed.
+     *
+     * @return bool
+     */
+    public function initPermissions()
+    {
+        // Checks if the PermissionManagerServiceProvider exists
+        if (! class_exists('Backpack\PermissionManager\PermissionManagerServiceProvider')) {
+            return false;
+        }
+
+        // Creates the permissions that doesn't already exists
+        if (config('crud-extended.create_permissions_while_browsing', false)) {
+            $this->createMissingPermissions();
+        }
+
+        // Gives the current's CRUD permissions to the currently connected user
+        if (config('crud-extended.give_permissions_to_current_user_while_browsing', false)) {
+            $user = Auth::user();
+            if (! empty($user)) {
+                $this->givePermissionsToUser($user);
+            }
+        }
+
+        // Applies permissions on the CRUD (denies/allows access from user permissions)
+        if (config('crud-extended.apply_permissions', false)) {
+            $this->initCrudAccessFromUserPermissions();
+        }
+
+        return true;
+    }
+
+    /**
+     * Gives all the permissions of the current CRUD to the specified user.
+     *
+     * @param \Illuminate\Contracts\Auth\Authenticatable $user
+     */
+    public function givePermissionsToUser($user)
+    {
+        // Assigns all permissions to user
+        $this->getPermissions()->each(function ($permission, $key) use ($user) {
+            try {
+                if (! $user->hasPermissionTo($permission)) {
+                    $user->givePermissionTo($permission);
+                }
+            } catch (PermissionDoesNotExist $e) {
+            }
+        });
+
+        // Reloads user permissions
+        $user->load('permissions');
+    }
+
+    /**
+     * Sets the permission prefix (instead of the default one).
+     *
+     * @param string|null $prefix
+     */
+    public function setPermissionsPrefix($prefix)
+    {
+        $this->permissionsPrefix = $prefix;
+    }
+
+    /**
+     * Gets the permission prefix.
+     *
+     * @return string
+     */
+    public function getPermissionPrefix()
+    {
+        if (! is_null($this->permissionsPrefix)) {
+            $prefix = $this->permissionsPrefix;
+        } else {
+            $prefix = $this->getDefaultPermissionPrefix();
+        }
+
+        return $prefix;
+    }
+
+    /**
+     * Get the default permission prefix (derived from the controller's namespace).
+     *
+     * @param bool $cached
+     * @return string
+     */
+    public function getDefaultPermissionPrefix($cached = true)
+    {
+        if (is_null($this->defaultPermissionPrefix) || ! $cached) {
+            $this->defaultPermissionPrefix = '';
+
+            if (! empty($this->controller)) {
+
+                // Splits the controller's namespace and extracts the class name
+                $namespaceParts = collect(explode('\\', trim(get_class($this->controller), '\\')));
+                $className = $namespaceParts->pop();
+
+                $namespaceParts = $namespaceParts->map(function ($value) {
+                    return mb_strtolower($value);
+                });
+
+                // Removes the app/vendor prefix from namespace
+                $namespaceParts = $namespaceParts->slice($namespaceParts->first() === 'app' ? 1 : 2);
+
+                // Prepends "admin" to the prefix if present in the namespace or if it's a CRUD controller.
+                // Redundant words like "crud" or "backpack" are also removed.
+                if (is_subclass_of($this->controller, CrudController::class) || $namespaceParts->contains('admin')) {
+                    $namespaceParts = $namespaceParts->diff(['backpack', 'admin', 'crud'])->prepend('admin');
+                }
+
+                // Removes excluded words from namespace and class name
+                $excludedWords = config('crud-extended.excluded_words_from_default_permission_prefix', []);
+                $namespaceParts = $namespaceParts->diff($excludedWords);
+                $className = collect(explode('_', snake_case($className)))->diff($excludedWords)->implode('.');
+
+                // Builds the prefix
+                $prefix = implode('.', array_merge($namespaceParts->toArray(), [$className]));
+
+                $this->defaultPermissionPrefix = (string) $prefix;
+            }
+        }
+
+        return $this->defaultPermissionPrefix;
+    }
+
+    /**
+     * Gets the permissions.
+     *
+     * @return Collection
+     */
+    public function getPermissions()
+    {
+        $prefix = $this->getPermissionPrefix();
+
+        $permissions = collect($this->availablePermissions)->map(function ($item, $key) use ($prefix) {
+            return $this->getPrefixedPermission($item);
+        });
+
+        return $permissions;
+    }
+
+    /**
+     * Gets the prefixed permission item.
+     *
+     * @param $item
+     * @return string
+     */
+    protected function getPrefixedPermission($item)
+    {
+        $permission = $item;
+
+        // Adds the prefix
+        $prefix = $this->getPermissionPrefix();
+        if (! empty($prefix)) {
+            $permission = $prefix.'::'.$permission;
+        }
+
+        return $permission;
+    }
+
+    /**
+     * Gets the permissions that are missing in database.
+     *
+     * @return Collection
+     */
+    public function getMissingPermissions()
+    {
+        $prefix = $this->getPermissionPrefix();
+
+        // Gets the existing permissions
+        $databasePermissions = \Backpack\PermissionManager\app\Models\Permission::where('name', 'like', $prefix.'::%')
+            ->get(['name'])
+            ->pluck('name');
+
+        // Gets the diff with available permissions
+        $missingPermissions = $this->getPermissions()->diff($databasePermissions);
+
+        return $missingPermissions;
+    }
+
+    /**
+     * Creates the missing permissions in database.
+     *
+     * @return Collection
+     */
+    public function createMissingPermissions()
+    {
+        $permissions = $this->getMissingPermissions();
+        if ($permissions->isNotEmpty()) {
+            $this->createPermissions($permissions);
+        }
+
+        return $permissions;
+    }
+
+    /**
+     * Creates the specified permissions in database.
+     *
+     * @param Collection $permissions
+     * @return bool
+     */
+    protected function createPermissions($permissions)
+    {
+        // Add missing permissions to DB
+        $datas = $permissions->map(function ($permissionName, $key) {
+            return ['name' => $permissionName, 'created_at' => Carbon::now()];
+        });
+
+        $inserted = \Backpack\PermissionManager\app\Models\Permission::insert($datas->toArray());
+
+        // Forget permissions cache
+        app(\Backpack\PermissionManager\app\Models\Permission::class)->forgetCachedPermissions();
+
+        return $inserted;
+    }
+
+    /**
+     * Initializes the CRUD access from the current user's permissions.
+     */
+    protected function initCrudAccessFromUserPermissions()
+    {
+        // Gets the CRUD permissions
+        $permissions = $this->getPermissions();
+
+        // Gets the current user
+        $user = Auth::user();
+        if (empty($user)) {
+            return;
+        }
+
+        // Denies access for each permission that the user has not
+        $permissions->each(function ($permission, $key) use ($user) {
+            try {
+                if (! $user->hasPermissionTo($permission)) {
+                    $this->denyAccess($this->extractPermissionKey($permission));
+                }
+            } catch (PermissionDoesNotExist $e) {
+                // If permission does not exists : we deny access for security reasons
+                $this->denyAccess($this->extractPermissionKey($permission));
+            }
+        });
+    }
+
+    /**
+     * Extracts the permission key.
+     *
+     * @param $permission
+     * @return string
+     */
+    protected function extractPermissionKey($permission)
+    {
+        return str_after($permission, '::');
+    }
+}


### PR DESCRIPTION
Today Backpack is frustrating because packages doesn't communicate with each other. 
Backpack gives [Laravel-Backpack/PermissionManager package](https://github.com/Laravel-Backpack/PermissionManager) but after installation no permission are created / used. 
Would it be perfect that this package was compatible and usable with CRUD isn't it ?
This is what this PR offers ! :champagne: 

**Summary**
- Permissions can now be applied automatically to CRUD Controllers : deny access if user hasn't the permission linked to the route => `apply_permissions` option
- Permissions can now be automatically created for all Crud Controllers used in you application (4 permissions will be created : list, update, create, delete) => `create_permissions_while_browsing` option
- Permissions can be automatically given to the logged user (useful in local environment)  => `give_permissions_to_current_user_while_browsing` option

**Configuration**
By default these features are disabled. There is no breaking change :smile: !
You can enable them in ` config/backpack/crud.php`.

**Command**
An artisan command is available to generate automatically CRUD permissions :
`php artisan permissions:generate`