### PR TITLE
Add Laravel 5.5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,13 @@ In your terminal:
 composer require novius/laravel-backpack-crud-extended
 ```
 
-
-In `config/app.php`, replace
-
-```php
-Backpack\CRUD\CrudServiceProvider::class,
-```
-
-by
+Then, if you are on Laravel 5.4 (no need for Laravel 5.5 and higher), register the service provider to your `config/app.php` file:
 
 ```php
-Novius\Backpack\CRUD\CrudServiceProvider::class,
+'providers' => [
+    ...
+    Novius\Backpack\CRUD\CrudServiceProvider::class,
+];
 ```
 
 

--- a/composer.json
+++ b/composer.json
@@ -49,5 +49,15 @@
         "test" : [
             "phpunit"
         ]
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Novius\\Backpack\\CRUD\\CrudServiceProvider"
+            ]
+        }
+    },
+    "config": {
+        "sort-packages": true
     }
 }

--- a/src/CrudServiceProvider.php
+++ b/src/CrudServiceProvider.php
@@ -2,12 +2,12 @@
 
 namespace Novius\Backpack\CRUD;
 
-use Backpack\CRUD\CrudServiceProvider as BackpackCrudServiceProvider;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Validator;
 use Novius\Backpack\CRUD\Console\PermissionsCommand;
+use Illuminate\Support\ServiceProvider;
 
-class CrudServiceProvider extends BackpackCrudServiceProvider
+class CrudServiceProvider extends ServiceProvider
 {
     protected static $configName = 'crud-extended';
     /**
@@ -25,16 +25,15 @@ class CrudServiceProvider extends BackpackCrudServiceProvider
          * - vendor/novius/backpack-crud/extended/resources/views/foo.blade.php
          * - vendor/backpack/crud/resources/views/foo.blade.php
          */
-        $this->loadViewsFrom(resource_path('views/vendor/backpack/crud'), 'crud');
-        $this->loadViewsFrom(realpath(dirname(__DIR__).'/resources/views'), 'crud');
-        parent::boot();
+        $this->app['view']->prependNamespace('crud', dirname(__DIR__).'/resources/views');
+        $this->app['view']->prependNamespace('crud', resource_path('views/vendor/backpack/crud'));
 
         /*
          * Add a new namespace "backpackcrud", to allow bypassing overrided views
          *
          * For instance, you can called an original backpack view using "backpackcrud::foo"
          */
-        $this->loadViewsFrom(realpath(dirname(__DIR__, 3).'/backpack/crud/src/resources/views'), 'backpackcrud');
+        $this->loadViewsFrom(dirname(__DIR__, 3).'/backpack/crud/src/resources/views', 'backpackcrud');
 
         /*
          * Publish overrided views
@@ -44,7 +43,7 @@ class CrudServiceProvider extends BackpackCrudServiceProvider
         /*
          * Publish config
          */
-        $this->publishes([__DIR__.'/../config/'.static::$configName.'.php' => config_path(static::$configName.'.php')], 'config');
+        $this->publishes([dirname(__DIR__).'/config/'.static::$configName.'.php' => config_path(static::$configName.'.php')], 'config');
 
         /*
          * Overrides original CrudPanel
@@ -74,10 +73,8 @@ class CrudServiceProvider extends BackpackCrudServiceProvider
      */
     public function register()
     {
-        parent::register();
-
         // Load config
-        $configPath = __DIR__.'/../config/'.static::$configName.'.php';
+        $configPath = dirname(__DIR__).'/config/'.static::$configName.'.php';
         $this->mergeConfigFrom($configPath, static::$configName);
 
         if ($this->app->runningInConsole()) {


### PR DESCRIPTION
- Add package autodiscovery ;
- Breaking change: our Service Provider no longer extends original Backpack ServiceProvider : under Laravel 5.4, you have now to register both service provider in your config file.