### PR TITLE
Able to custom back to all URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,17 @@ $this->crud->addField([
 ]);
 ```
 
+### CRUD : index route
+
+You can set a custom value to index route.
+In that case, "back to all" button and breadcrumb's link on your CRUD will overridden. 
+This route is available with `$crud->indexRoute()`.
+ 
+Example of usage in your CrudController : 
+```php
+// Set a custom index route
+$this->crud->setIndexRoute('crud.slide.index', ['slideshow' => (int) request('slideshow')]);
+```
 
 ## Testing
 

--- a/resources/views/create.blade.php
+++ b/resources/views/create.blade.php
@@ -1,5 +1,18 @@
 @extends('backpackcrud::create')
 
+@section('header')
+    <section class="content-header">
+        <h1>
+            {{ trans('backpack::crud.add') }} <span>{{ $crud->entity_name }}</span>
+        </h1>
+        <ol class="breadcrumb">
+            <li><a href="{{ url(config('backpack.base.route_prefix'), 'dashboard') }}">{{ trans('backpack::crud.admin') }}</a></li>
+            <li><a href="{{ url($crud->indexRoute()) }}" class="text-capitalize">{{ $crud->entity_name_plural }}</a></li>
+            <li class="active">{{ trans('backpack::crud.add') }}</li>
+        </ol>
+    </section>
+@endsection
+
 @section('content')
 	{!! Form::open(array('url' => $crud->route, 'method' => 'post', 'files'=>$crud->hasUploadFields('create'))) !!}
 	  @include('crud::form_content', [ 'fields' => $crud->getFields('create'), 'action' => 'create' ])

--- a/resources/views/edit.blade.php
+++ b/resources/views/edit.blade.php
@@ -1,5 +1,18 @@
 @extends('backpackcrud::edit')
 
+@section('header')
+    <section class="content-header">
+        <h1>
+            {{ trans('backpack::crud.edit') }} <span>{{ $crud->entity_name }}</span>
+        </h1>
+        <ol class="breadcrumb">
+            <li><a href="{{ url(config('backpack.base.route_prefix'),'dashboard') }}">{{ trans('backpack::crud.admin') }}</a></li>
+            <li><a href="{{ url($crud->indexRoute()) }}" class="text-capitalize">{{ $crud->entity_name_plural }}</a></li>
+            <li class="active">{{ trans('backpack::crud.edit') }}</li>
+        </ol>
+    </section>
+@endsection
+
 @section('content')
 	{!! Form::open(array('url' => $crud->route.'/'.$entry->getKey(), 'method' => 'put', 'files'=>$crud->hasUploadFields('update', $entry->getKey()))) !!}
 	  @include('crud::form_content', ['fields' => $fields, 'action' => 'edit', 'entry' => $entry])

--- a/resources/views/form_content.blade.php
+++ b/resources/views/form_content.blade.php
@@ -6,7 +6,7 @@
     <div class="{{ $crud->sideBoxesEnabled() ? 'col-md-12' : 'col-md-8 col-md-offset-2' }}">
         <!-- Default box -->
         @if ($crud->hasAccess('list'))
-            <a href="{{ url($crud->route) }}"><i class="fa fa-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a><br><br>
+            <a href="{{ $crud->backtoAllUrl() }}"><i class="fa fa-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a><br><br>
         @endif
 
         @if ($crud->model->translationEnabled())

--- a/resources/views/form_content.blade.php
+++ b/resources/views/form_content.blade.php
@@ -6,7 +6,7 @@
     <div class="{{ $crud->sideBoxesEnabled() ? 'col-md-12' : 'col-md-8 col-md-offset-2' }}">
         <!-- Default box -->
         @if ($crud->hasAccess('list'))
-            <a href="{{ $crud->backtoAllUrl() }}"><i class="fa fa-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a><br><br>
+            <a href="{{ url($crud->indexRoute()) }}"><i class="fa fa-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a><br><br>
         @endif
 
         @if ($crud->model->translationEnabled())

--- a/src/CrudPanel.php
+++ b/src/CrudPanel.php
@@ -13,6 +13,8 @@ class CrudPanel extends BackpackCrudPanel
 
     protected $langFile;
 
+    protected $backToAllRoute;
+
     /**
      * Set the lang file to use
      * Used all over the CRUD interface (header, add button, reorder button, breadcrumbs).
@@ -33,5 +35,31 @@ class CrudPanel extends BackpackCrudPanel
     public function getLangFile()
     {
         return $this->langFile ?? 'backpack::crud';
+    }
+
+    /**
+     * Set a route for back to all button
+     *
+     * @param $routeName
+     * @param array $parameters
+     * @throws \Exception
+     */
+    public function setBackToAllRouteRouteName($routeName, $parameters = [])
+    {
+        if (!\Route::has($routeName)) {
+            throw new \Exception('There are no routes for this route name.', 404);
+        }
+
+        $this->backToAllRoute = route($routeName, $parameters);
+    }
+
+    /**
+     * Get back to all URL
+     *
+     * @return \Illuminate\Contracts\Routing\UrlGenerator|string
+     */
+    public function backtoAllUrl()
+    {
+        return empty($this->backToAllRoute) ? url($this->route) : url($this->backToAllRoute);
     }
 }

--- a/src/CrudPanel.php
+++ b/src/CrudPanel.php
@@ -5,15 +5,15 @@ namespace Novius\Backpack\CRUD;
 use Backpack\CRUD\CrudPanel as BackpackCrudPanel;
 use Novius\Backpack\CRUD\PanelTraits\Boxes;
 use Novius\Backpack\CRUD\PanelTraits\BoxTabs;
+use Novius\Backpack\CRUD\PanelTraits\Routes;
 
 class CrudPanel extends BackpackCrudPanel
 {
     use Boxes;
     use BoxTabs;
+    use Routes;
 
     protected $langFile;
-
-    protected $backToAllRoute;
 
     /**
      * Set the lang file to use
@@ -35,31 +35,5 @@ class CrudPanel extends BackpackCrudPanel
     public function getLangFile()
     {
         return $this->langFile ?? 'backpack::crud';
-    }
-
-    /**
-     * Set a route for back to all button
-     *
-     * @param $routeName
-     * @param array $parameters
-     * @throws \Exception
-     */
-    public function setBackToAllRouteRouteName($routeName, $parameters = [])
-    {
-        if (!\Route::has($routeName)) {
-            throw new \Exception('There are no routes for this route name.', 404);
-        }
-
-        $this->backToAllRoute = route($routeName, $parameters);
-    }
-
-    /**
-     * Get back to all URL
-     *
-     * @return \Illuminate\Contracts\Routing\UrlGenerator|string
-     */
-    public function backtoAllUrl()
-    {
-        return empty($this->backToAllRoute) ? url($this->route) : url($this->backToAllRoute);
     }
 }

--- a/src/PanelTraits/Routes.php
+++ b/src/PanelTraits/Routes.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Novius\Backpack\CRUD\PanelTraits;
+
+trait Routes
+{
+    protected $indexRoute;
+
+    /**
+     * Set a custom index route
+     *
+     * @param $routeName
+     * @param array $parameters
+     * @throws \Exception
+     */
+    public function setIndexRoute($routeName, $parameters = [])
+    {
+        if (!\Route::has($routeName)) {
+            throw new \Exception('There are no routes for this route name.', 404);
+        }
+
+        $this->indexRoute = route($routeName, $parameters);
+    }
+
+    /**
+     * Get the index route
+     *
+     * @return string
+     */
+    public function indexRoute()
+    {
+        return empty($this->indexRoute) ? $this->route : $this->indexRoute;
+    }
+}

--- a/src/PanelTraits/Routes.php
+++ b/src/PanelTraits/Routes.php
@@ -27,8 +27,8 @@ trait Routes
      *
      * @return string
      */
-    public function indexRoute()
+    public function indexRoute() : string
     {
-        return empty($this->indexRoute) ? $this->route : $this->indexRoute;
+        return $this->indexRoute ?? $this->route;
     }
 }


### PR DESCRIPTION
In some case, back to all route must be different than `$crud->route`.
For example when index route requires GET parameter.

**Feature :** 

You can set a custom value to index route.
In that case, "back to all" button and breadcrumb's link on your CRUD will overridden. 
This route is available with `$crud->indexRoute()`.
 
Example of usage in your CrudController : 
```php
// Set a custom index route
$this->crud->setIndexRoute('crud.slide.index', ['slideshow' => (int) request('slideshow')]);
```