### PR TITLE
Feature : reorder route 

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,16 +269,20 @@ $this->crud->addField([
 ]);
 ```
 
-### CRUD : index route
+### CRUD : custom routes
 
-You can set a custom value to index route.
-In that case, "back to all" button and breadcrumb's link on your CRUD will overridden. 
-This route is available with `$crud->indexRoute()`.
+You can set a custom value to some routes.
+
+- Index route : used with "back to all" button or breadcrumb's link. Available with `$crud->indexRoute()`.
+- Reorder route : used with "Reorder button". Available with `$crud->reorderRoute()`.
  
 Example of usage in your CrudController : 
 ```php
 // Set a custom index route
 $this->crud->setIndexRoute('crud.slide.index', ['slideshow' => (int) request('slideshow')]);
+
+// Set a custom reorder route
+$this->crud->setReorderRoute('crud.slide.reorder', ['slideshow' => (int) request('slideshow')]);
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ $this->crud->setReorderRoute('crud.slide.reorder', ['slideshow' => (int) request
 ## Testing
 
 Run the tests with:
-Add 
+
 ```bash
 ./test.sh
 ```

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ $this->crud->setReorderRoute('crud.slide.reorder', ['slideshow' => (int) request
 ## Testing
 
 Run the tests with:
-
+Add 
 ```bash
 ./test.sh
 ```

--- a/resources/views/buttons/reorder.blade.php
+++ b/resources/views/buttons/reorder.blade.php
@@ -1,0 +1,5 @@
+@if ($crud->reorder)
+	@if ($crud->hasAccess('reorder'))
+	  <a href="{{ url($crud->reorderRoute()) }}" class="btn btn-default ladda-button" data-style="zoom-in"><span class="ladda-label"><i class="fa fa-arrows"></i> {{ trans('backpack::crud.reorder') }} {{ $crud->entity_name_plural }}</span></a>
+	@endif
+@endif

--- a/resources/views/reorder.blade.php
+++ b/resources/views/reorder.blade.php
@@ -1,0 +1,95 @@
+@extends('backpackcrud::reorder')
+<?php
+    if (isset($reorder_filter_callback) && is_callable($reorder_filter_callback)) {
+        $entries = $entries->filter($reorder_filter_callback);
+    }
+?>
+
+@section('header')
+    <section class="content-header">
+        <h1>
+            <span class="text-capitalize">{{ $crud->entity_name_plural }}</span>
+            <small>{{ trans('backpack::crud.all') }} <span>{{ $crud->entity_name_plural }}</span> {{ trans('backpack::crud.in_the_database') }}.</small>
+        </h1>
+        <ol class="breadcrumb">
+            <li><a href="{{ url(config('backpack.base.route_prefix'), 'dashboard') }}">{{ trans('backpack::crud.admin') }}</a></li>
+            <li><a href="{{ url($crud->indexRoute()) }}" class="text-capitalize">{{ $crud->entity_name_plural }}</a></li>
+            <li class="active">{{ trans('backpack::crud.reorder') }}</li>
+        </ol>
+    </section>
+@endsection
+
+@section('content')
+    <?php
+    function tree_element_overrided($entry, $key, $all_entries, $crud)
+    {
+        if (!isset($entry->tree_element_shown)) {
+            // mark the element as shown
+            $all_entries[$key]->tree_element_shown = true;
+            $entry->tree_element_shown = true;
+
+            // show the tree element
+            echo '<li id="list_'.$entry->getKey().'">';
+            echo '<div><span class="disclose"><span></span></span>'.object_get($entry, $crud->reorder_label).'</div>';
+
+            // see if this element has any children
+            $children = [];
+            foreach ($all_entries as $key => $subentry) {
+                if ($subentry->parent_id == $entry->getKey()) {
+                    $children[] = $subentry;
+                }
+            }
+
+            $children = collect($children)->sortBy('lft');
+
+            // if it does have children, show them
+            if (count($children)) {
+                echo '<ol>';
+                foreach ($children as $key => $child) {
+                    $children[$key] = tree_element_overrided($child, $child->getKey(), $all_entries, $crud);
+                }
+                echo '</ol>';
+            }
+            echo '</li>';
+        }
+
+        return $entry;
+    }
+
+    ?>
+    <div class="row">
+        <div class="col-md-8 col-md-offset-2">
+            @if ($crud->hasAccess('list'))
+                <a href="{{ url($crud->indexRoute()) }}"><i class="fa fa-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a><br><br>
+        @endif
+
+        <!-- Default box -->
+            <div class="box">
+
+                <div class="box-header with-border">
+                    <h3 class="box-title">{{ trans('backpack::crud.reorder').' '.$crud->entity_name_plural }}</h3>
+                </div>
+
+                <div class="box-body">
+
+                    <p>{{ trans('backpack::crud.reorder_text') }}</p>
+
+                    <ol class="sortable">
+                        <?php
+                        $all_entries = collect($entries->all())->sortBy('lft')->keyBy($crud->getModel()->getKeyName());
+                        $root_entries = $all_entries->filter(function ($item) {
+                            return $item->parent_id == 0;
+                        });
+                        foreach ($root_entries as $key => $entry) {
+                            $root_entries[$key] = tree_element_overrided($entry, $key, $all_entries, $crud);
+                        }
+                        ?>
+                    </ol>
+
+                    <button id="toArray" class="btn btn-success ladda-button" data-style="zoom-in"><span class="ladda-label"><i class="fa fa-save"></i> {{ trans('backpack::crud.save') }}</span></button>
+
+                </div><!-- /.box-body -->
+            </div><!-- /.box -->
+        </div>
+    </div>
+@endsection

--- a/resources/views/reorder.blade.php
+++ b/resources/views/reorder.blade.php
@@ -21,8 +21,7 @@
 
 @section('content')
     <?php
-    function tree_element_overrided($entry, $key, $all_entries, $crud)
-    {
+    $treeElementFunction = function ($entry, $key, $all_entries, $crud) use ($treeElementFunction) {
         if (!isset($entry->tree_element_shown)) {
             // mark the element as shown
             $all_entries[$key]->tree_element_shown = true;
@@ -46,7 +45,7 @@
             if (count($children)) {
                 echo '<ol>';
                 foreach ($children as $key => $child) {
-                    $children[$key] = tree_element_overrided($child, $child->getKey(), $all_entries, $crud);
+                    $children[$key] = $treeElementFunction($child, $child->getKey(), $all_entries, $crud);
                 }
                 echo '</ol>';
             }
@@ -81,7 +80,7 @@
                             return $item->parent_id == 0;
                         });
                         foreach ($root_entries as $key => $entry) {
-                            $root_entries[$key] = tree_element_overrided($entry, $key, $all_entries, $crud);
+                            $root_entries[$key] = $treeElementFunction($entry, $key, $all_entries, $crud);
                         }
                         ?>
                     </ol>

--- a/src/PanelTraits/Routes.php
+++ b/src/PanelTraits/Routes.php
@@ -5,6 +5,7 @@ namespace Novius\Backpack\CRUD\PanelTraits;
 trait Routes
 {
     protected $indexRoute;
+    protected $reorderRoute;
 
     /**
      * Set a custom index route
@@ -27,8 +28,34 @@ trait Routes
      *
      * @return string
      */
-    public function indexRoute() : string
+    public function indexRoute(): string
     {
         return $this->indexRoute ?? $this->route;
+    }
+
+    /**
+     * Set a reorder route
+     *
+     * @param $routeName
+     * @param array $parameters
+     * @throws \Exception
+     */
+    public function setReorderRoute($routeName, $parameters = [])
+    {
+        if (!\Route::has($routeName)) {
+            throw new \Exception('There are no routes for this route name.', 404);
+        }
+
+        $this->reorderRoute = route($routeName, $parameters);
+    }
+
+    /**
+     * Get the reorder route
+     *
+     * @return string
+     */
+    public function reorderRoute(): string
+    {
+        return $this->reorderRoute ?? $this->route.'/reorder';
     }
 }


### PR DESCRIPTION
Following https://github.com/novius/laravel-backpack-crud-extended/pull/13

You can now set a custom value to some routes.

- Index route : used with "back to all" button or breadcrumb's link. Available with `$crud->indexRoute()`.
- Reorder route : used with "Reorder button". Available with `$crud->reorderRoute()`.
 
Example of usage in your CrudController : 
```php
// Set a custom index route
$this->crud->setIndexRoute('crud.slide.index', ['slideshow' => (int) request('slideshow')]);

// Set a custom reorder route
$this->crud->setReorderRoute('crud.slide.reorder', ['slideshow' => (int) request('slideshow')]);
```