### PR TITLE
Specify a manually default box for crud fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ $this->crud->setBoxOptions('Details', [
 
 If you forget to specify a tab name for a field, Backpack will place it in the last box.
 
+You can specify manually a default box in the crud file.
+If your field doesn't have the box attribute, this field will be displayed in this default box.
+
+```php
+$this->crud->setDefaultBox('YourBoxName');
+```
 
 ### Fields Drivers
 

--- a/src/PanelTraits/Boxes.php
+++ b/src/PanelTraits/Boxes.php
@@ -6,6 +6,7 @@ trait Boxes
 {
     public $sideBoxesEnabled = false;
     public $boxesOptions = [];
+    public $defaultBox = null;
 
     public function enableSideBoxes() : bool
     {
@@ -41,6 +42,11 @@ trait Boxes
     public function getLastBox()
     {
         $boxes = $this->getBoxes();
+
+        // A default box is manually defined, we have to return it
+        if ($this->defaultBox !== null) {
+            return $this->defaultBox;
+        }
 
         if (count($boxes)) {
             return last($boxes);
@@ -106,11 +112,22 @@ trait Boxes
         return $boxOptions;
     }
 
+    public function setDefaultBox(string $defaultBoxName) : void
+    {
+        $this->defaultBox = $defaultBoxName;
+    }
+
     public function getBoxes($columnFilter = null) : array
     {
         $boxes = [];
         $fields = $this->getCurrentFields();
 
+        // If DefaultBox is defined manually, we have to add it
+        if ($this->defaultBox !== null && ($columnFilter === 'side' xor ! $this->getBoxOptions($this->defaultBox)['side'])) {
+            $boxes[] = $this->defaultBox;
+        }
+
+        // Find all boxes using fields
         collect($fields)
             ->filter(function ($value, $key) {
                 return isset($value['box']);
@@ -123,7 +140,7 @@ trait Boxes
                 }
             });
 
-        // Default Box
+        // Add an automatic DefaultBox if needle
         if (empty($boxes) && $columnFilter !== 'side') {
             $boxes[] = ucfirst($this->entity_name);
         }


### PR DESCRIPTION
Possibility to add a default name box in the Crud to display fields in it. (If the field are no box defined).