### PR TITLE
Fixed the way images are saved, adding the correct extension type at the end of the fileName

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     },
     "scripts": {
         "lint" : [
-            "php-cs-fixer fix --dry-run --config .php_cs -vv --diff  --allow-risky=yes"
+            "php-cs-fixer fix --dry-run --config .php_cs -vv --diff --allow-risky=yes"
         ],
         "test" : [
             "phpunit"

--- a/src/ModelTraits/UploadableImage.php
+++ b/src/ModelTraits/UploadableImage.php
@@ -41,6 +41,11 @@ trait UploadableImage
             $this->setTranslation($imageAttributeName, (string) request('locale', $this->getLocale()), $path); // Default value is relevant when using seeders or any environment where we dont have acces to "request".
         } else {
             $this->{$imageAttributeName} = $path;
+
+            if (!empty($path)) {
+                $path = preg_replace('/\?v=.*/', '', $path);
+                $this->{$imageAttributeName} = $path.'?v='.md5(time());
+            }
         }
     }
 

--- a/src/ModelTraits/UploadableImage.php
+++ b/src/ModelTraits/UploadableImage.php
@@ -39,12 +39,17 @@ trait UploadableImage
             && $this->isTranslatableAttribute($imageAttributeName)
         ) {
             $this->setTranslation($imageAttributeName, (string) request('locale', $this->getLocale()), $path); // Default value is relevant when using seeders or any environment where we dont have acces to "request".
+
+            if (!empty($path)) {
+                $path = preg_replace('/\?v=.*/', '', $path);
+                $this->setTranslation($imageAttributeName, (string) request('locale', $this->getLocale()), $path.'?v='.uniqid());
+            }
         } else {
             $this->{$imageAttributeName} = $path;
 
             if (!empty($path)) {
                 $path = preg_replace('/\?v=.*/', '', $path);
-                $this->{$imageAttributeName} = $path.'?v='.md5(time());
+                $this->{$imageAttributeName} = $path.'?v='.uniqid();
             }
         }
     }

--- a/src/Services/UploadImageService.php
+++ b/src/Services/UploadImageService.php
@@ -3,13 +3,20 @@
 namespace Novius\Backpack\CRUD\Services;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\Log;
+
 /**
  * Class UploadImageService
  * @package Novius\Backpack\CRUD\Services
  */
 class UploadImageService extends AbstractUploadService
 {
+    /**
+     * Allowed image extensions
+     *
+     * @var array
+     */
+    protected $allowed_extensions = ['gif', 'png', 'jpeg', 'jpg'];
+
     /**
      * Filled with images during model saving
      * Images will be used on Model "saved" event
@@ -210,7 +217,6 @@ class UploadImageService extends AbstractUploadService
 
         $path_parts = pathinfo($value);
         $path_extension = !empty($path_parts['extension']) ? $path_parts['extension'] : false;
-        $allowed_extensions = ['gif', 'png', 'jpeg', 'jpg'];
 
         // Image is removed
         if (empty($value)) {
@@ -227,14 +233,14 @@ class UploadImageService extends AbstractUploadService
         }
 
         // An image is already uploaded, a new one is uploaded
-        if (str_contains($path_extension, $allowed_extensions) && !empty($originalValue)) {
+        if (str_contains($path_extension, $this->allowed_extensions) && !empty($originalValue)) {
             $this->setNewImage($value, $originalValue, $imageAttributeName);
 
             return;
         }
 
         // No image is uploaded
-        if (str_contains($path_extension, $allowed_extensions)) {
+        if (str_contains($path_extension, $this->allowed_extensions)) {
             $this->model->fillUploadedImageAttributeValue($imageAttributeName, '');
 
             return;

--- a/src/Services/UploadImageService.php
+++ b/src/Services/UploadImageService.php
@@ -15,7 +15,7 @@ class UploadImageService extends AbstractUploadService
      *
      * @var array
      */
-    protected $allowed_extensions = ['jpeg', 'jpg'];
+    protected $allowed_extensions = ['jpeg', 'jpg', 'gif', 'png'];
 
     /**
      * Filled with images during model saving
@@ -57,7 +57,7 @@ class UploadImageService extends AbstractUploadService
 
         foreach ($this->tmpImages as $imageAttributeName => $image) {
             // 1. Get image path
-            $filePath = $this->getImagePath($imageAttributeName);
+            $filePath = $this->getImagePath($imageAttributeName, $image->mime);
 
             // 2. Store the image on disk.
             \Storage::disk(self::STORAGE_DISK_NAME)->put($filePath, $image->stream());
@@ -83,16 +83,18 @@ class UploadImageService extends AbstractUploadService
      * @param $imageAttributeName
      * @return string
      */
-    protected function getImagePath(string $imageAttributeName): string
+    protected function getImagePath(string $imageAttributeName, string $mime): string
     {
+        $extension = str_replace_first('image/', '.', $mime);
+
         $folderName = snake_case(class_basename(get_class($this->model)));
         $destination_path = $folderName.'/'.$this->model->getKey().'/'.$imageAttributeName;
         $imageSlugAttribute = array_get($this->slugAttributes($this->model->uploadableImages()), $imageAttributeName);
 
         // 1. Generate a filename.
-        $filename = md5(time()).'.jpg';
+        $filename = md5(time()).$extension;
         if (!empty($imageSlugAttribute)) {
-            $filename = str_slug($this->model->{$imageSlugAttribute}).'.jpg';
+            $filename = str_slug($this->model->{$imageSlugAttribute}).$extension;
         }
 
         return $destination_path.'/'.$filename;

--- a/src/Services/UploadImageService.php
+++ b/src/Services/UploadImageService.php
@@ -10,6 +10,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 class UploadImageService extends AbstractUploadService
 {
+    const R_MD5_MATCH = '/\?v=[a-f0-9]{32}$/';
+
     /**
      * Filled with images during model saving
      * Images will be used on Model "saved" event
@@ -223,14 +225,14 @@ class UploadImageService extends AbstractUploadService
         }
 
         // An image is already uploaded, a new one is uploaded
-        if (ends_with($value, '.jpg') && !empty($originalValue)) {
+        if (preg_match(self::R_MD5_MATCH, $value) && !empty($originalValue)) {
             $this->setNewImage($value, $originalValue, $imageAttributeName);
 
             return;
         }
 
         // No image is uploaded
-        if (!ends_with($value, '.jpg')) {
+        if (!preg_match(self::R_MD5_MATCH, $value)) {
             $this->model->fillUploadedImageAttributeValue($imageAttributeName, '');
 
             return;

--- a/src/Services/UploadImageService.php
+++ b/src/Services/UploadImageService.php
@@ -234,14 +234,14 @@ class UploadImageService extends AbstractUploadService
         }
 
         // An image is already uploaded, a new one is uploaded
-        if (in_array($pathExtension, $this->allowed_extensions) && !empty($originalValue)) {
+        if (str_contains($pathExtension, $this->allowed_extensions) && !empty($originalValue)) {
             $this->setNewImage($value, $originalValue, $imageAttributeName);
 
             return;
         }
 
         // No image is uploaded
-        if (!in_array($pathExtension, $this->allowed_extensions)) {
+        if (!str_contains($pathExtension, $this->allowed_extensions)) {
             $this->model->fillUploadedImageAttributeValue($imageAttributeName, '');
 
             return;

--- a/src/Services/UploadImageService.php
+++ b/src/Services/UploadImageService.php
@@ -15,7 +15,7 @@ class UploadImageService extends AbstractUploadService
      *
      * @var array
      */
-    protected $allowed_extensions = ['jpeg', 'jpg', 'gif', 'png'];
+    protected $allowedExtensions = ['jpeg', 'jpg', 'gif', 'png'];
 
     /**
      * Filled with images during model saving
@@ -234,14 +234,14 @@ class UploadImageService extends AbstractUploadService
         }
 
         // An image is already uploaded, a new one is uploaded
-        if (starts_with($pathExtension, $this->allowed_extensions) && !empty($originalValue)) {
+        if (starts_with($pathExtension, $this->allowedExtensions) && !empty($originalValue)) {
             $this->setNewImage($value, $originalValue, $imageAttributeName);
 
             return;
         }
 
         // No image is uploaded
-        if (!starts_with($pathExtension, $this->allowed_extensions)) {
+        if (!starts_with($pathExtension, $this->allowedExtensions)) {
             $this->model->fillUploadedImageAttributeValue($imageAttributeName, '');
 
             return;

--- a/src/Services/UploadImageService.php
+++ b/src/Services/UploadImageService.php
@@ -234,14 +234,14 @@ class UploadImageService extends AbstractUploadService
         }
 
         // An image is already uploaded, a new one is uploaded
-        if (str_contains($pathExtension, $this->allowed_extensions) && !empty($originalValue)) {
+        if (starts_with($pathExtension, $this->allowed_extensions) && !empty($originalValue)) {
             $this->setNewImage($value, $originalValue, $imageAttributeName);
 
             return;
         }
 
         // No image is uploaded
-        if (!str_contains($pathExtension, $this->allowed_extensions)) {
+        if (!starts_with($pathExtension, $this->allowed_extensions)) {
             $this->model->fillUploadedImageAttributeValue($imageAttributeName, '');
 
             return;

--- a/src/Services/UploadImageService.php
+++ b/src/Services/UploadImageService.php
@@ -217,8 +217,7 @@ class UploadImageService extends AbstractUploadService
             $originalValue = $this->model->getOriginal($imageAttributeName);
         }
 
-        $path_parts = pathinfo($value);
-        $path_extension = array_get($path_parts, 'extension');
+        $pathExtension = pathinfo($value, PATHINFO_EXTENSION);
 
         // Image is removed
         if (empty($value)) {
@@ -235,14 +234,14 @@ class UploadImageService extends AbstractUploadService
         }
 
         // An image is already uploaded, a new one is uploaded
-        if (str_contains($path_extension, $this->allowed_extensions) && !empty($originalValue)) {
+        if (in_array($pathExtension, $this->allowed_extensions) && !empty($originalValue)) {
             $this->setNewImage($value, $originalValue, $imageAttributeName);
 
             return;
         }
 
         // No image is uploaded
-        if (!str_contains($path_extension, $this->allowed_extensions)) {
+        if (!in_array($pathExtension, $this->allowed_extensions)) {
             $this->model->fillUploadedImageAttributeValue($imageAttributeName, '');
 
             return;

--- a/src/Services/UploadImageService.php
+++ b/src/Services/UploadImageService.php
@@ -240,7 +240,7 @@ class UploadImageService extends AbstractUploadService
         }
 
         // No image is uploaded
-        if (str_contains($path_extension, $this->allowed_extensions)) {
+        if (!str_contains($path_extension, $this->allowed_extensions)) {
             $this->model->fillUploadedImageAttributeValue($imageAttributeName, '');
 
             return;

--- a/src/Services/UploadImageService.php
+++ b/src/Services/UploadImageService.php
@@ -3,15 +3,13 @@
 namespace Novius\Backpack\CRUD\Services;
 
 use Illuminate\Database\Eloquent\Model;
-
+use Illuminate\Support\Facades\Log;
 /**
  * Class UploadImageService
  * @package Novius\Backpack\CRUD\Services
  */
 class UploadImageService extends AbstractUploadService
 {
-    const R_MD5_MATCH = '/\?v=[a-f0-9]{32}$/';
-
     /**
      * Filled with images during model saving
      * Images will be used on Model "saved" event
@@ -210,6 +208,10 @@ class UploadImageService extends AbstractUploadService
             $originalValue = $this->model->getOriginal($imageAttributeName);
         }
 
+        $path_parts = pathinfo($value);
+        $path_extension = !empty($path_parts['extension']) ? $path_parts['extension'] : false;
+        $allowed_extensions = ['gif', 'png', 'jpeg', 'jpg'];
+
         // Image is removed
         if (empty($value)) {
             $this->deleteOldImage($originalValue, $imageAttributeName);
@@ -225,14 +227,14 @@ class UploadImageService extends AbstractUploadService
         }
 
         // An image is already uploaded, a new one is uploaded
-        if (preg_match(self::R_MD5_MATCH, $value) && !empty($originalValue)) {
+        if (str_contains($path_extension, $allowed_extensions) && !empty($originalValue)) {
             $this->setNewImage($value, $originalValue, $imageAttributeName);
 
             return;
         }
 
         // No image is uploaded
-        if (!preg_match(self::R_MD5_MATCH, $value)) {
+        if (str_contains($path_extension, $allowed_extensions)) {
             $this->model->fillUploadedImageAttributeValue($imageAttributeName, '');
 
             return;

--- a/src/Services/UploadImageService.php
+++ b/src/Services/UploadImageService.php
@@ -15,7 +15,7 @@ class UploadImageService extends AbstractUploadService
      *
      * @var array
      */
-    protected $allowed_extensions = ['gif', 'png', 'jpeg', 'jpg'];
+    protected $allowed_extensions = ['jpeg', 'jpg'];
 
     /**
      * Filled with images during model saving
@@ -216,7 +216,7 @@ class UploadImageService extends AbstractUploadService
         }
 
         $path_parts = pathinfo($value);
-        $path_extension = !empty($path_parts['extension']) ? $path_parts['extension'] : false;
+        $path_extension = array_get($path_parts, 'extension');
 
         // Image is removed
         if (empty($value)) {


### PR DESCRIPTION
## Fixed the way images are saved, adding the correct extension type at the end of the fileName

Images are now saved with the right extension type, who is extracted from the MIME.
