### PR TITLE
Fix attributes (getter, setter, filesAttributes)

### DIFF
--- a/src/ModelTraits/UploadableFile.php
+++ b/src/ModelTraits/UploadableFile.php
@@ -41,7 +41,7 @@ trait UploadableFile
             //
             $this->setTranslation($fileAttributeName, (string) request('locale', $this->getLocale()), $path); // Default value is relevant when using seeders or any environment where we dont have acces to "request".
         } else {
-            $this->{$fileAttributeName} = $path;
+            $this->setAttribute($fileAttributeName, $path);
         }
     }
 

--- a/src/ModelTraits/UploadableImage.php
+++ b/src/ModelTraits/UploadableImage.php
@@ -41,7 +41,7 @@ trait UploadableImage
         if ($this->isTranslatableImageAttribute($imageAttributeName)) {
             $this->setTranslation($imageAttributeName, $this->getLocale(), $uniquePath);
         } else {
-            $this->{$imageAttributeName} = $uniquePath;
+            $this->setAttribute($imageAttributeName, $uniquePath);
         }
     }
 

--- a/src/Services/AbstractUploadService.php
+++ b/src/Services/AbstractUploadService.php
@@ -21,6 +21,10 @@ abstract class AbstractUploadService
      */
     protected function filesAttributes(array $uploableFiles): array
     {
+        if (empty($uploableFiles)) {
+            return [];
+        }
+
         if (array_get($uploableFiles, 0) === null) {
             $uploableFiles = [$uploableFiles];
         }

--- a/src/Services/UploadFileService.php
+++ b/src/Services/UploadFileService.php
@@ -78,7 +78,7 @@ class UploadFileService extends AbstractUploadService
         $slugAttributeName = array_get($this->slugAttributes($this->model->uploadableFiles()), $fileAttributeName);
         $filename = md5(time());
         if (!empty($slugAttributeName)) {
-            $filename = str_slug($this->model->{$slugAttributeName});
+            $filename = str_slug($this->model->getAttribute($slugAttributeName));
         }
         $filename .= '.'.$file->getClientOriginalExtension();
 
@@ -107,7 +107,7 @@ class UploadFileService extends AbstractUploadService
     {
         $this->initModel($model);
         foreach ($this->filesAttributes($this->model->uploadableFiles()) as $fileAttribute) {
-            \Storage::disk(self::STORAGE_DISK_NAME)->delete($this->model->{$fileAttribute});
+            \Storage::disk(self::STORAGE_DISK_NAME)->delete($this->model->getAttribute($fileAttribute));
         }
 
         return true;

--- a/src/Services/UploadImageService.php
+++ b/src/Services/UploadImageService.php
@@ -94,7 +94,7 @@ class UploadImageService extends AbstractUploadService
         // 1. Generate a filename.
         $filename = md5(time()).$extension;
         if (!empty($imageSlugAttribute)) {
-            $filename = str_slug($this->model->{$imageSlugAttribute}).$extension;
+            $filename = str_slug($this->model->getAttribute($imageSlugAttribute)).$extension;
         }
 
         return $destination_path.'/'.$filename;
@@ -110,7 +110,7 @@ class UploadImageService extends AbstractUploadService
     {
         $this->initModel($model);
         foreach ($this->filesAttributes($this->model->uploadableImages()) as $imageAttribute) {
-            $this->deleteImage($imageAttribute, $this->model->{$imageAttribute});
+            $this->deleteImage($imageAttribute, $this->model->getAttribute($imageAttribute));
         }
 
         return true;
@@ -213,7 +213,7 @@ class UploadImageService extends AbstractUploadService
                 $originalValue = array_get($originalValue, $locale, null);
             }
         } else {
-            $value = $this->model->{$imageAttributeName};
+            $value = $this->model->getAttribute($imageAttributeName);
             $originalValue = $this->model->getOriginal($imageAttributeName);
         }
 


### PR DESCRIPTION
Use setter and getter for model attributes. It will allow overloading `setAttribute` and `getAttribute` on the model for custom behaviours on the files and images attributes, like storing them in the `extras` field (c3613fd4c6caa1c8eedfa472e0d6224dd17e8026 and 86426b8a37e8335519450156827034e7b1614064).

Allow empty files attributes (0c41c8b9449de94bd8c7f9a0fea3a8d862d82147).