### PR TITLE
Adds dependency to laravelcollective/html

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     ],
     "require": {
         "php": ">=7.1",
-        "backpack/crud": "~3.3.0"
+        "backpack/crud": "~3.3.0",
+        "laravelcollective/html": "^5.5.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.8.0",


### PR DESCRIPTION
Adds a dependency to `laravelcollective/html` as we use the `Form` facade.

Fix #37.