### PR TITLE
HasMediaTrait with additional features (conversions, translatable...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,11 +334,44 @@ class Example extends Model
 }
 ```
 
-#### MediaLibrary
+#### MediaLibrary (7.*)
 
-If you want to store the images in the [MediaLibrary](https://github.com/spatie/laravel-medialibrary) provided by Spatie, use the trait `SpatieMediaLibrary\UploadableImage` instead of `UploadableImage`.
+With the [MediaLibrary](https://github.com/spatie/laravel-medialibrary) provided by Spatie you can easily manage conversions (crop, resize, ...).
 
-For example with the MediaLibrary you can easily manage conversions (crop, resize, ...).
+To store the images in the MediaLibrary, you just have to implement the following traits on your model :
+* `SpatieMediaLibrary\UploadableImage` instead of `UploadableImage`
+* `SpatieMediaLibrary\HasMediaTrait` instead of the one provided by the MediaLibrary.
+
+Here is an example on how to configure and use crop and fit max conversions on your model :
+```php
+    protected $mediaConversionsCrop = [
+          'background' => [
+                'large' => [1440, 810],
+                'medium' => [1080, 608],
+                'small' => [768, 432],
+          ],
+    ];
+
+    protected $mediaConversionsFitMax = [
+          'background' => [
+                'large' => [877, 900],
+                'medium' => [670, 687],
+                'small' => [580, 594],
+          ],
+    ];
+
+    public function backgroundFullCropUrl()
+    {
+        return $this->getAttributeMediaCropUrl('background', 'large', true);
+    }
+
+    public function backgroundFullFitMaxUrl()
+    {
+        return $this->getAttributeMediaFitMaxUrl('background', 'large', true);
+    }
+```
+
+Check the documentation of the [MediaLibrary](https://github.com/spatie/laravel-medialibrary) to go further.
 
 #### Translations
 

--- a/src/ModelTraits/SpatieMediaLibrary/HasMediaTrait.php
+++ b/src/ModelTraits/SpatieMediaLibrary/HasMediaTrait.php
@@ -18,32 +18,6 @@ trait HasMediaTrait
     use HasMediaTraitNative;
 
     /**
-     * The crop conversions
-     *
-     * @var array
-     */
-//    protected $mediaConversionsCrop = [
-//         'picture' => [ // The attribute name
-//             'full' => [1440, 810], // An example of conversion
-//             'medium' => [1080, 608], // Another example of conversion
-//             'small' => [768, 432], // A third example of conversion
-//         ]
-//    ];
-
-    /**
-     * The fit max conversions
-     *
-     * @var array
-     */
-//    protected $mediaConversionsFitMax = [
-//         'picture' => [ // The attribute name
-//             'full' => [877, 900], // An example of conversion
-//             'medium' => [670, 687], // Another example of conversion
-//             'small' => [580, 594], // A third example of conversion
-//         ],
-//    ];
-
-    /**
      * Gets the attribute media URL with a fallback on the media stored on disk.
      *
      * @param string $attributeName

--- a/src/ModelTraits/SpatieMediaLibrary/HasMediaTrait.php
+++ b/src/ModelTraits/SpatieMediaLibrary/HasMediaTrait.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Novius\Backpack\CRUD\ModelTraits\SpatieMediaLibrary;
+
+use Spatie\Image\Manipulations;
+use Spatie\MediaLibrary\HasMedia\HasMediaTrait as HasMediaTraitNative;
+use Spatie\MediaLibrary\Models\Media;
+
+/**
+ * Overrides the native HasMediaTrait trait to add some additional features :
+ * - adds some methods to work with medias stored as attributes (for example with the UploadableImage trait)
+ * - adds some properties and methods to easily handle conversions (crop and fit max)
+ *
+ * @package Novius\Backpack\CRUD\ModelTraits\SpatieMediaLibrary
+ */
+trait HasMediaTrait
+{
+    use HasMediaTraitNative;
+
+    /**
+     * The crop conversions
+     *
+     * @var array
+     */
+//    protected $mediaConversionsCrop = [
+//         'picture' => [ // The attribute name
+//             'full' => [1440, 810], // An example of conversion
+//             'medium' => [1080, 608], // Another example of conversion
+//             'small' => [768, 432], // A third example of conversion
+//         ]
+//    ];
+
+    /**
+     * The fit max conversions
+     *
+     * @var array
+     */
+//    protected $mediaConversionsFitMax = [
+//         'picture' => [ // The attribute name
+//             'full' => [877, 900], // An example of conversion
+//             'medium' => [670, 687], // Another example of conversion
+//             'small' => [580, 594], // A third example of conversion
+//         ],
+//    ];
+
+    /**
+     * Gets the attribute media URL with a fallback on the media stored on disk.
+     *
+     * @param string $attributeName
+     * @param string $conversionName
+     * @param bool $fallbackOnDisk Whether to fallback on the media stored on disk if the media collection doesn't exists
+     * @return \Illuminate\Contracts\Routing\UrlGenerator|null|string
+     */
+    public function getAttributeMediaUrl(string $attributeName, string $conversionName = '', bool $fallbackOnDisk = true)
+    {
+        // Gets the URL from the media collection
+        $collectionName = $this->getAttributeMediaCollectionName($attributeName);
+        $url = $this->getFirstMediaUrl($collectionName, $conversionName);
+
+        if (empty($url) && $fallbackOnDisk) {
+            // Gets the URL from the media stored on disk as fallback
+            $url = $this->getAttributeMediaUrlFromDisk($attributeName);
+        }
+
+        return url($url);
+    }
+
+    /**
+     * Gets the attribute media URL with crop conversion and with a fallback on the media stored on disk.
+     *
+     * @param string $attributeName
+     * @param string $cropConversionName
+     * @param bool $fallbackOnDisk
+     * @return \Illuminate\Contracts\Routing\UrlGenerator|null|string
+     */
+    public function getAttributeMediaCropUrl(string $attributeName, string $cropConversionName, bool $fallbackOnDisk = true)
+    {
+        return $this->getAttributeMediaUrl($attributeName, 'crop-'.$cropConversionName, $fallbackOnDisk);
+    }
+
+    /**
+     * Gets the attribute media URL with fit max conversion and with a fallback on the media stored on disk.
+     *
+     * @param string $attributeName
+     * @param string $fitMaxConversionName
+     * @param bool $fallbackOnDisk
+     * @return \Illuminate\Contracts\Routing\UrlGenerator|null|string
+     */
+    public function getAttributeMediaFitMaxUrl(string $attributeName, string $fitMaxConversionName, bool $fallbackOnDisk = true)
+    {
+        return $this->getAttributeMediaUrl($attributeName, 'fitmax-'.$fitMaxConversionName, $fallbackOnDisk);
+    }
+
+    /**
+     * Gets the attribute media URL from disk.
+     *
+     * @param string $attributeName
+     * @return \Illuminate\Contracts\Routing\UrlGenerator|string
+     */
+    public function getAttributeMediaUrlFromDisk(string $attributeName)
+    {
+        return \Storage::disk('public')->url($this->getAttribute($attributeName));
+    }
+
+    /**
+     * Gets the localized collection name of the attribute media.
+     *
+     * @param string $mediaAttributeName
+     * @param string|null $locale
+     * @return string
+     */
+    public function getAttributeMediaCollectionName(string $mediaAttributeName, string $locale = null)
+    {
+        $collectionName = $mediaAttributeName;
+
+        // Appends the locale if translatable
+        if ($this->isTranslatableAttributeMedia($mediaAttributeName)) {
+            $collectionName .= '-'.($locale ?? $this->getLocale());
+        }
+
+        return $collectionName;
+    }
+
+    /**
+     * Checks if the given attribute media is translatable.
+     *
+     * @param string $attributeName
+     * @return bool
+     */
+    public function isTranslatableAttributeMedia(string $attributeName)
+    {
+        return method_exists($this, 'isTranslatableAttribute') && $this->isTranslatableAttribute($attributeName);
+    }
+
+    /**
+     * Registers the crop conversions from the property "mediaConversionsCrop".
+     *
+     * @throws \Spatie\Image\Exceptions\InvalidManipulation
+     */
+    public function registerMediaConversionsCrop()
+    {
+        if (!property_exists($this, 'mediaConversionsCrop')) {
+            return;
+        }
+
+        foreach ($this->mediaConversionsCrop as $collectionName => $conversions) {
+            foreach ($conversions as $conversionName => $dimensions) {
+                $this->addMediaConversion('crop-'.$conversionName)
+                    ->crop(Manipulations::CROP_CENTER, $dimensions[0], $dimensions[1])
+                    ->optimize()
+                    ->performOnCollections($collectionName);
+            }
+        }
+    }
+
+    /**
+     * Registers the fit max conversions from the property "mediaConversionsFitMax".
+     *
+     * @throws \Spatie\Image\Exceptions\InvalidManipulation
+     */
+    public function registerMediaConversionsFitMax()
+    {
+        if (!property_exists($this, 'mediaConversionsFitMax')) {
+            return;
+        }
+
+        foreach ($this->mediaConversionsFitMax as $collectionName => $conversions) {
+            foreach ($conversions as $conversionName => $dimensions) {
+                $this->addMediaConversion('fitmax-'.$conversionName)
+                    ->fit(Manipulations::FIT_MAX, $dimensions[0], $dimensions[1])
+                    ->optimize()
+                    ->performOnCollections($collectionName);
+            }
+        }
+    }
+
+    /**
+     * Automatically registers the media conversions defined via properties.
+     *
+     * @param Media|null $media
+     * @throws \Spatie\Image\Exceptions\InvalidManipulation
+     */
+    public function registerMediaConversions(Media $media = null)
+    {
+        $this->registerMediaConversionsCrop();
+        $this->registerMediaConversionsFitMax();
+    }
+}

--- a/src/ModelTraits/SpatieMediaLibrary/UploadableImage.php
+++ b/src/ModelTraits/SpatieMediaLibrary/UploadableImage.php
@@ -8,7 +8,7 @@ use Novius\Backpack\CRUD\ModelTraits\UploadableImage as UploadableImageOriginal;
  * Trait UploadableImage
  *
  * To make media upload work :
- * - implement the trait Spatie\MediaLibrary\HasMedia\HasMediaTrait on your model
+ * - implement the trait Novius\Backpack\CRUD\ModelTraits\SpatieMediaLibrary\HasMediaTrait on your model
  * - call $this->setUploadedImage($value) in your model attribute mutator
  *
  * @package Novius\Backpack\CRUD\ModelTraits\SpatieMediaLibrary


### PR DESCRIPTION
Adds a new trait `HasMediaTrait` that can be used instead of the one provided by [spatie/medialibrary](https://github.com/spatie/laravel-medialibrary) to implement some additional features and work with medias from translatable attribute.

For example with this trait you can easily configure and use crop and fit max conversions on your model :
```php
protected $mediaConversionsCrop = [
      'background' => [
            'large' => [1440, 810],
            'medium' => [1080, 608],
            'small' => [768, 432],
      ],
];

protected $mediaConversionsFitMax = [
      'background' => [
            'large' => [877, 900],
            'medium' => [670, 687],
            'small' => [580, 594],
      ],
];

public function backgroundFullCropUrl()
{
    return $this->getAttributeMediaCropUrl('background', 'large', true);
}

public function backgroundFullFitMaxUrl()
{
    return $this->getAttributeMediaFitMaxUrl('background', 'large', true);
}
```
