### PR TITLE
Check attribute image exists before deleting it

### DIFF
--- a/src/Services/UploadImageService.php
+++ b/src/Services/UploadImageService.php
@@ -110,7 +110,13 @@ class UploadImageService extends AbstractUploadService
     {
         $this->initModel($model);
         foreach ($this->filesAttributes($this->model->uploadableImages()) as $imageAttribute) {
-            $this->deleteImage($imageAttribute, $this->model->getAttribute($imageAttribute));
+            $imageRelativePath = $this->model->getAttribute($imageAttribute);
+            if (
+                !empty($imageRelativePath &&
+                \Storage::disk(self::STORAGE_DISK_NAME)->exists($imageRelativePath))
+            ) {
+                $this->deleteImage($imageAttribute, $this->model->getAttribute($imageAttribute));
+            }
         }
 
         return true;

--- a/src/Services/UploadImageService.php
+++ b/src/Services/UploadImageService.php
@@ -112,8 +112,8 @@ class UploadImageService extends AbstractUploadService
         foreach ($this->filesAttributes($this->model->uploadableImages()) as $imageAttribute) {
             $imageRelativePath = $this->model->getAttribute($imageAttribute);
             if (
-                !empty($imageRelativePath &&
-                \Storage::disk(self::STORAGE_DISK_NAME)->exists($imageRelativePath))
+                !empty($imageRelativePath) &&
+                \Storage::disk(self::STORAGE_DISK_NAME)->exists($imageRelativePath)
             ) {
                 $this->deleteImage($imageAttribute, $this->model->getAttribute($imageAttribute));
             }


### PR DESCRIPTION
Not doing so could potentially throw an error, preventing object deletion